### PR TITLE
Fix lobby event handlers cleanup

### DIFF
--- a/Assets/Scripts/LobbyPlayerListManager.cs
+++ b/Assets/Scripts/LobbyPlayerListManager.cs
@@ -33,6 +33,12 @@ public class LobbyPlayerListManager : NetworkBehaviour
 
     private void OnDisable()
     {
+        if (IsServer && NetworkManager.Singleton != null)
+        {
+            NetworkManager.OnClientConnectedCallback -= OnClientConnected;
+            NetworkManager.OnClientDisconnectCallback -= OnClientDisconnected;
+        }
+
         if (connectedClientIds != null)
         {
             connectedClientIds.OnListChanged -= OnListChangedLog;


### PR DESCRIPTION
## Summary
- unhook server callbacks when disabling the lobby manager

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f53c30f48322ab16e95bcc5348d3