### PR TITLE
Improve card hand interactions

### DIFF
--- a/Assets/Scripts/CardDraggable.cs
+++ b/Assets/Scripts/CardDraggable.cs
@@ -3,15 +3,34 @@ using UnityEngine;
 public class CardDraggable : MonoBehaviour
 {
     private Vector3 offset;
-    private Vector3 originalPosition;
     private Camera cam;
-
     private bool isDragging = false;
+    private float originalZ;
+    private HandLayoutFanStyle layout;
+    private Vector3 previousPos;
+    public float rotationMultiplier = 30f;
 
     void Start()
     {
         cam = Camera.main;
-        originalPosition = transform.position;
+        layout = transform.parent?.GetComponent<HandLayoutFanStyle>();
+    }
+
+    void OnMouseEnter()
+    {
+        if (isDragging) return;
+        originalZ = transform.localPosition.z;
+        Vector3 pos = transform.localPosition;
+        pos.z = 0.1f;
+        transform.localPosition = pos;
+    }
+
+    void OnMouseExit()
+    {
+        if (isDragging) return;
+        Vector3 pos = transform.localPosition;
+        pos.z = originalZ;
+        transform.localPosition = pos;
     }
 
     void OnMouseDown()
@@ -19,6 +38,7 @@ public class CardDraggable : MonoBehaviour
         isDragging = true;
         Vector3 mouseWorld = cam.ScreenToWorldPoint(Input.mousePosition);
         offset = transform.position - new Vector3(mouseWorld.x, mouseWorld.y, transform.position.z);
+        previousPos = transform.position;
     }
 
     void OnMouseDrag()
@@ -26,14 +46,18 @@ public class CardDraggable : MonoBehaviour
         if (!isDragging) return;
 
         Vector3 mouseWorld = cam.ScreenToWorldPoint(Input.mousePosition);
-        transform.position = new Vector3(mouseWorld.x + offset.x, mouseWorld.y + offset.y, transform.position.z);
+        Vector3 target = new Vector3(mouseWorld.x + offset.x, mouseWorld.y + offset.y, transform.position.z);
+        Vector3 delta = target - previousPos;
+        float angle = Mathf.Atan2(delta.y, delta.x) * Mathf.Rad2Deg * rotationMultiplier;
+        transform.rotation = Quaternion.Lerp(transform.rotation, Quaternion.Euler(0, 0, angle), Time.deltaTime * 10f);
+        transform.position = target;
+        previousPos = target;
     }
 
     void OnMouseUp()
     {
         isDragging = false;
-
-        // Ýleride: Slot kontrolü buraya gelecek
-        transform.position = originalPosition;
+        transform.rotation = Quaternion.identity;
+        layout?.UpdateLayout();
     }
 }

--- a/Assets/Scripts/DeckManager.cs
+++ b/Assets/Scripts/DeckManager.cs
@@ -52,6 +52,12 @@ public class DeckManager : MonoBehaviour
 
     public CardEntry SpawnCardToHand()
     {
+        if (handAreaTransform.childCount >= 4)
+        {
+            Debug.Log("Hand is full. Max 4 cards allowed.");
+            return null;
+        }
+
         var cardData = DrawCard();
         if (cardData == null)
         {

--- a/Assets/Scripts/HandLayoutFanStyle.cs
+++ b/Assets/Scripts/HandLayoutFanStyle.cs
@@ -2,29 +2,25 @@ using UnityEngine;
 
 public class HandLayoutFanStyle : MonoBehaviour
 {
-    public float radius = 2f;
-    public float angleSpread = 15f;
+    public float spacing = 1f;
+    public float curveHeight = 0.3f;
+    public float rotationScale = 5f;
     public float depthOffset = 0.01f;
+    public float verticalShift = 0f;
 
     public void UpdateLayout()
     {
         int count = transform.childCount;
         if (count == 0) return;
 
-        float totalAngle = Mathf.Min(angleSpread * (count - 1), 60f);
-        float startAngle = -totalAngle / 2f;
-
         for (int i = 0; i < count; i++)
         {
             Transform card = transform.GetChild(i);
-
-            float angle = startAngle + angleSpread * i;
-            float rad = Mathf.Deg2Rad * angle;
-
-            float x = Mathf.Sin(rad) * radius;
-            float y = Mathf.Cos(rad) * radius;
+            float x = (i - (count - 1) / 2f) * spacing;
+            float y = -Mathf.Abs(x) * curveHeight + verticalShift;
 
             card.localPosition = new Vector3(x, y, -i * depthOffset);
+            float angle = x * rotationScale;
             card.localRotation = Quaternion.Euler(0, 0, angle);
         }
     }


### PR DESCRIPTION
## Summary
- prevent drawing more than four cards
- fan layout spreads cards horizontally
- allow cards to be dragged with rotation
- hovered cards pop forward visually

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f92c563883229ea9b3def256c91d