### PR TITLE
Fine-tune hand layout and hover handling

### DIFF
--- a/Assets/Scripts/CardDraggable.cs
+++ b/Assets/Scripts/CardDraggable.cs
@@ -11,7 +11,7 @@ public class CardDraggable : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
     private Vector3 previousPos;
     public float rotationMultiplier = 30f;
     public float hoverHeight = 0.5f;
-    public float hoverForward = 1.5f;
+    public float hoverForward = 2f;
     private bool isHovered = false;
 
     void Start()
@@ -27,7 +27,7 @@ public class CardDraggable : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
         originalPos = transform.localPosition;
         Vector3 pos = originalPos;
         pos.y += hoverHeight;
-        pos.z += hoverForward;
+        pos.z = hoverForward;
         transform.localPosition = pos;
     }
 

--- a/Assets/Scripts/CardDraggable.cs
+++ b/Assets/Scripts/CardDraggable.cs
@@ -1,14 +1,18 @@
 using UnityEngine;
+using UnityEngine.EventSystems;
 
-public class CardDraggable : MonoBehaviour
+public class CardDraggable : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, IPointerDownHandler, IDragHandler, IPointerUpHandler
 {
     private Vector3 offset;
     private Camera cam;
     private bool isDragging = false;
-    private float originalZ;
+    private Vector3 originalPos;
     private HandLayoutFanStyle layout;
     private Vector3 previousPos;
     public float rotationMultiplier = 30f;
+    public float hoverHeight = 0.5f;
+    public float hoverForward = 1.5f;
+    private bool isHovered = false;
 
     void Start()
     {
@@ -16,24 +20,25 @@ public class CardDraggable : MonoBehaviour
         layout = transform.parent?.GetComponent<HandLayoutFanStyle>();
     }
 
-    void OnMouseEnter()
+    public void OnPointerEnter(PointerEventData eventData)
     {
-        if (isDragging) return;
-        originalZ = transform.localPosition.z;
-        Vector3 pos = transform.localPosition;
-        pos.z = 0.1f;
+        if (isDragging || isHovered) return;
+        isHovered = true;
+        originalPos = transform.localPosition;
+        Vector3 pos = originalPos;
+        pos.y += hoverHeight;
+        pos.z += hoverForward;
         transform.localPosition = pos;
     }
 
-    void OnMouseExit()
+    public void OnPointerExit(PointerEventData eventData)
     {
-        if (isDragging) return;
-        Vector3 pos = transform.localPosition;
-        pos.z = originalZ;
-        transform.localPosition = pos;
+        if (isDragging || !isHovered) return;
+        isHovered = false;
+        transform.localPosition = originalPos;
     }
 
-    void OnMouseDown()
+    public void OnPointerDown(PointerEventData eventData)
     {
         isDragging = true;
         Vector3 mouseWorld = cam.ScreenToWorldPoint(Input.mousePosition);
@@ -41,7 +46,7 @@ public class CardDraggable : MonoBehaviour
         previousPos = transform.position;
     }
 
-    void OnMouseDrag()
+    public void OnDrag(PointerEventData eventData)
     {
         if (!isDragging) return;
 
@@ -54,9 +59,10 @@ public class CardDraggable : MonoBehaviour
         previousPos = target;
     }
 
-    void OnMouseUp()
+    public void OnPointerUp(PointerEventData eventData)
     {
         isDragging = false;
+        isHovered = false;
         transform.rotation = Quaternion.identity;
         layout?.UpdateLayout();
     }

--- a/Assets/Scripts/DeckManager.cs
+++ b/Assets/Scripts/DeckManager.cs
@@ -66,7 +66,7 @@ public class DeckManager : MonoBehaviour
         }
 
         GameObject cardObj = Instantiate(cardPrefab, handAreaTransform);
-        cardObj.transform.localScale = Vector3.one;
+        cardObj.transform.localScale = Vector3.one * 0.8f;
         cardObj.transform.localPosition = Vector3.zero;
 
         var display = cardObj.GetComponent<CardDisplay>();

--- a/Assets/Scripts/HandLayoutFanStyle.cs
+++ b/Assets/Scripts/HandLayoutFanStyle.cs
@@ -2,11 +2,16 @@ using UnityEngine;
 
 public class HandLayoutFanStyle : MonoBehaviour
 {
-    public float spacing = 1f;
-    public float curveHeight = 0.3f;
-    public float rotationScale = 5f;
-    public float depthOffset = 0.01f;
-    public float verticalShift = 0f;
+    // Wider spacing so cards don't overlap
+    public float spacing = 1.5f;
+    // Higher curve to keep cards fully visible
+    public float curveHeight = 0.25f;
+    // Rotation independent from spacing for a consistent fan
+    public float rotationScale = 7f;
+    // Keep cards one unit apart on the Z axis
+    public float depthOffset = 1f;
+    // Raise the whole hand to fit on screen
+    public float verticalShift = 1f;
 
     public void UpdateLayout()
     {
@@ -15,11 +20,12 @@ public class HandLayoutFanStyle : MonoBehaviour
         for (int i = 0; i < count; i++)
         {
             Transform card = transform.GetChild(i);
-            float x = (i - (count - 1) / 2f) * spacing;
-            float y = -Mathf.Abs(x) * curveHeight + verticalShift;
+            float offsetIndex = i - (count - 1) / 2f;
+            float x = offsetIndex * spacing;
+            float y = -Mathf.Abs(offsetIndex) * curveHeight + verticalShift;
 
             card.localPosition = new Vector3(x, y, -i * depthOffset);
-            float angle = x * rotationScale;
+            float angle = offsetIndex * rotationScale;
             card.localRotation = Quaternion.Euler(0, 0, angle);
         }
     }

--- a/Assets/Scripts/HandLayoutFanStyle.cs
+++ b/Assets/Scripts/HandLayoutFanStyle.cs
@@ -2,16 +2,16 @@ using UnityEngine;
 
 public class HandLayoutFanStyle : MonoBehaviour
 {
-    // Wider spacing so cards don't overlap
-    public float spacing = 1.5f;
-    // Higher curve to keep cards fully visible
-    public float curveHeight = 0.25f;
-    // Rotation independent from spacing for a consistent fan
-    public float rotationScale = 7f;
+    // Wider spacing so cards barely overlap
+    public float spacing = 1.75f;
+    // Higher curve so cards stay visible
+    public float curveHeight = 0.3f;
+    // Slightly stronger rotation for a fuller fan
+    public float rotationScale = 8f;
     // Keep cards one unit apart on the Z axis
     public float depthOffset = 1f;
-    // Raise the whole hand to fit on screen
-    public float verticalShift = 1f;
+    // Raise the whole hand so cards are fully visible
+    public float verticalShift = 1.5f;
 
     public void UpdateLayout()
     {


### PR DESCRIPTION
## Summary
- switch `CardDraggable` to pointer events to avoid overlapping hover events
- add options for hover height and forward offset
- raise and spread cards more in `HandLayoutFanStyle` for better visibility

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530457279c8322a07fcfc4567a9771