### PR TITLE
Add card hover spread and preview

### DIFF
--- a/Assets/Scripts/CardDraggable.cs
+++ b/Assets/Scripts/CardDraggable.cs
@@ -24,12 +24,18 @@ public class CardDraggable : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
 
     public void OnPointerEnter(PointerEventData eventData)
     {
-        // Hover effect disabled
+        if (isDragging || isHovered) return;
+        isHovered = true;
+        layout?.SpreadOut();
+        CardPreviewManager.Instance?.ShowPreview(gameObject);
     }
 
     public void OnPointerExit(PointerEventData eventData)
     {
-        // Hover effect disabled
+        if (!isHovered || isDragging) return;
+        isHovered = false;
+        layout?.Restore();
+        CardPreviewManager.Instance?.HidePreview();
     }
 
     public void OnPointerDown(PointerEventData eventData)
@@ -70,5 +76,6 @@ public class CardDraggable : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
             transform.SetParent(originalParent, true);
         }
         layout?.UpdateLayout();
+        CardPreviewManager.Instance?.HidePreview();
     }
 }

--- a/Assets/Scripts/CardPreviewManager.cs
+++ b/Assets/Scripts/CardPreviewManager.cs
@@ -1,0 +1,45 @@
+using UnityEngine;
+
+public class CardPreviewManager : MonoBehaviour
+{
+    public static CardPreviewManager Instance { get; private set; }
+
+    [Header("Preview Settings")]
+    public Vector3 previewPosition = Vector3.zero;
+    public float previewScale = 3f;
+
+    private GameObject currentPreview;
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    private static void Init()
+    {
+        var go = new GameObject("CardPreviewManager");
+        go.AddComponent<CardPreviewManager>();
+        DontDestroyOnLoad(go);
+    }
+
+    private void Awake()
+    {
+        Instance = this;
+    }
+
+    public void ShowPreview(GameObject card)
+    {
+        HidePreview();
+        currentPreview = Instantiate(card, previewPosition, Quaternion.identity);
+        foreach (var drag in currentPreview.GetComponentsInChildren<CardDraggable>(true))
+            Destroy(drag);
+        foreach (var col in currentPreview.GetComponentsInChildren<Collider>(true))
+            Destroy(col);
+        currentPreview.transform.localScale = Vector3.one * previewScale;
+    }
+
+    public void HidePreview()
+    {
+        if (currentPreview != null)
+        {
+            Destroy(currentPreview);
+            currentPreview = null;
+        }
+    }
+}

--- a/Assets/Scripts/HandLayoutFanStyle.cs
+++ b/Assets/Scripts/HandLayoutFanStyle.cs
@@ -10,20 +10,71 @@ public class HandLayoutFanStyle : MonoBehaviour
     // Keep cards one unit apart on the Z axis
     public float depthOffset = 1f;
     public float verticalShift = 0f;
+
+    [Header("Hover Spread Settings")]
+    public float spreadMultiplier = 1.1f; // how much to spread when hovering
+    public float spreadDuration = 0.2f;   // duration of the spread animation
+
+    private float _baseSpacing;
+    private float _currentSpacing;
+    private Coroutine _spreadRoutine;
+
+    private void Awake()
+    {
+        _baseSpacing = spacing;
+        _currentSpacing = spacing;
+    }
+
     public void UpdateLayout()
+    {
+        _baseSpacing = spacing;
+        _currentSpacing = spacing;
+        ApplyLayout();
+    }
+
+    private void ApplyLayout()
     {
         int count = transform.childCount;
         if (count == 0) return;
+
         for (int i = 0; i < count; i++)
         {
             Transform card = transform.GetChild(i);
             float offsetIndex = i - (count - 1) / 2f;
-            float x = offsetIndex * spacing;
+            float x = offsetIndex * _currentSpacing;
             float y = -Mathf.Abs(offsetIndex) * curveHeight + verticalShift;
 
             card.localPosition = new Vector3(x, y, -i * depthOffset);
             float angle = offsetIndex * rotationScale;
             card.localRotation = Quaternion.Euler(0, 0, angle);
         }
+    }
+
+    private System.Collections.IEnumerator AnimateSpacing(float target)
+    {
+        float start = _currentSpacing;
+        float time = 0f;
+        while (time < spreadDuration)
+        {
+            time += Time.deltaTime;
+            _currentSpacing = Mathf.Lerp(start, target, time / spreadDuration);
+            ApplyLayout();
+            yield return null;
+        }
+        _currentSpacing = target;
+        ApplyLayout();
+        _spreadRoutine = null;
+    }
+
+    public void SpreadOut()
+    {
+        if (_spreadRoutine != null) StopCoroutine(_spreadRoutine);
+        _spreadRoutine = StartCoroutine(AnimateSpacing(_baseSpacing * spreadMultiplier));
+    }
+
+    public void Restore()
+    {
+        if (_spreadRoutine != null) StopCoroutine(_spreadRoutine);
+        _spreadRoutine = StartCoroutine(AnimateSpacing(_baseSpacing));
     }
 }


### PR DESCRIPTION
## Summary
- animate card layout spacing on hover
- show enlarged preview of hovered card in the middle
- allow customization of spread multiplier and animation duration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68545abc26348322840489afad0393d5