### PR TITLE
Add CityArea prefab system

### DIFF
--- a/Assets/Prefabs/CityAreaPrefab.prefab
+++ b/Assets/Prefabs/CityAreaPrefab.prefab
@@ -1,0 +1,50 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 100001}
+  - component: {fileID: 100002}
+  m_Layer: 0
+  m_Name: CityAreaPrefab
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &100001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &100002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1355e849608f4183a97e562af0e89f19, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  cityCenterSprite: {fileID: 0}
+  slotSprite: {fileID: 0}
+  horizontalSpacing: 1.2
+  verticalOffset: -0.2
+  baseSortingOrder: 10

--- a/Assets/Prefabs/CityAreaPrefab.prefab.meta
+++ b/Assets/Prefabs/CityAreaPrefab.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: de23c34b9c2f436086461d6baa32f822
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/CityAreaManager.cs
+++ b/Assets/Scripts/CityAreaManager.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class CityAreaManager : MonoBehaviour
+{
+    public Sprite cityCenterSprite;
+    public Sprite slotSprite;
+    public float horizontalSpacing = 1.2f;
+    public float verticalOffset = -0.2f;
+    public int baseSortingOrder = 10;
+
+    private readonly List<SlotController> rightSlots = new();
+    private readonly List<SlotController> leftSlots = new();
+
+    private void Awake()
+    {
+        BuildLayout();
+    }
+
+    private void BuildLayout()
+    {
+        Canvas canvas = GetComponent<Canvas>();
+        if (canvas == null)
+        {
+            canvas = gameObject.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.WorldSpace;
+        }
+
+        if (GetComponent<CanvasScaler>() == null)
+            gameObject.AddComponent<CanvasScaler>();
+        if (GetComponent<GraphicRaycaster>() == null)
+            gameObject.AddComponent<GraphicRaycaster>();
+
+        GameObject center = CreateUIElement("CityCenter", cityCenterSprite, baseSortingOrder + 1);
+        center.transform.SetParent(transform, false);
+
+        for (int i = 0; i < 5; i++)
+        {
+            SlotController right = CreateSlot(true, i);
+            rightSlots.Add(right);
+            SlotController left = CreateSlot(false, i);
+            leftSlots.Add(left);
+
+            if (i > 0)
+            {
+                right.gameObject.SetActive(false);
+                left.gameObject.SetActive(false);
+            }
+        }
+
+        UpdateSlotPositions();
+    }
+
+    private GameObject CreateUIElement(string name, Sprite sprite, int order)
+    {
+        GameObject obj = new GameObject(name, typeof(RectTransform), typeof(Canvas), typeof(CanvasRenderer), typeof(Image));
+        Canvas c = obj.GetComponent<Canvas>();
+        c.renderMode = RenderMode.WorldSpace;
+        c.overrideSorting = true;
+        c.sortingOrder = order;
+        Image img = obj.GetComponent<Image>();
+        img.sprite = sprite;
+        return obj;
+    }
+
+    private SlotController CreateSlot(bool rightSide, int index)
+    {
+        string n = (rightSide ? "RightSlot_" : "LeftSlot_") + index;
+        GameObject obj = CreateUIElement(n, slotSprite, baseSortingOrder - index);
+        obj.transform.SetParent(transform, false);
+
+        SlotController ctrl = obj.AddComponent<SlotController>();
+        ctrl.Initialize(this, rightSide, index);
+        ctrl.image = obj.GetComponent<Image>();
+        return ctrl;
+    }
+
+    private void UpdateSlotPositions()
+    {
+        for (int i = 0; i < leftSlots.Count; i++)
+        {
+            float x = -(i + 1) * horizontalSpacing;
+            float y = (i + 1) * verticalOffset;
+            leftSlots[i].transform.localPosition = new Vector3(x, y, 0);
+        }
+
+        for (int i = 0; i < rightSlots.Count; i++)
+        {
+            float x = (i + 1) * horizontalSpacing;
+            float y = (i + 1) * verticalOffset;
+            rightSlots[i].transform.localPosition = new Vector3(x, y, 0);
+        }
+    }
+
+    public void OnSlotFilled(SlotController slot)
+    {
+        List<SlotController> list = slot.IsRightSide ? rightSlots : leftSlots;
+        int next = slot.Index + 1;
+        if (next < list.Count)
+        {
+            list[next].gameObject.SetActive(true);
+        }
+    }
+}

--- a/Assets/Scripts/CityAreaManager.cs.meta
+++ b/Assets/Scripts/CityAreaManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1355e849608f4183a97e562af0e89f19
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/SlotController.cs
+++ b/Assets/Scripts/SlotController.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+public class SlotController : MonoBehaviour
+{
+    public bool IsRightSide;
+    public int Index;
+    public Image image;
+    public GameObject currentCard;
+    private CityAreaManager manager;
+
+    public void Initialize(CityAreaManager areaManager, bool rightSide, int index)
+    {
+        manager = areaManager;
+        IsRightSide = rightSide;
+        Index = index;
+    }
+
+    public void SetCard(GameObject card)
+    {
+        currentCard = card;
+        if (card != null && manager != null)
+        {
+            manager.OnSlotFilled(this);
+        }
+    }
+}

--- a/Assets/Scripts/SlotController.cs.meta
+++ b/Assets/Scripts/SlotController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2ddf9472cbe6403c8f226e65f4d32812
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add `CityAreaManager` script to build a city area with slots
- add `SlotController` script for individual slot logic
- create simple `CityAreaPrefab` prefab referencing the manager

## Testing
- `dotnet format --verify-no-changes` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68546c65a6a08322bfb4dfb306c5c16d