### PR TITLE
Fix slot initialization in CityAreaManager

### DIFF
--- a/Assets/Scripts/CityAreaManager.cs
+++ b/Assets/Scripts/CityAreaManager.cs
@@ -78,8 +78,8 @@ public class CityAreaManager : MonoBehaviour
         obj.transform.SetParent(slotParent, false);
 
         SlotController ctrl = obj.AddComponent<SlotController>();
-        ctrl.Initialize(this, rightSide, index);
-        ctrl.image = obj.GetComponent<Image>();
+        Image img = obj.GetComponent<Image>();
+        ctrl.Initialize(this, rightSide, index, img);
         return ctrl;
     }
 


### PR DESCRIPTION
## Summary
- fix `CreateSlot` to pass image reference to `SlotController.Initialize`

## Testing
- `dotnet build Sabodeus.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6854928353f88322998c7c2f55860f4b