### PR TITLE
Improve asset loading performance

### DIFF
--- a/Assets/Scripts/CardDisplay.cs
+++ b/Assets/Scripts/CardDisplay.cs
@@ -1,4 +1,5 @@
 using TMPro;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -14,6 +15,8 @@ public class CardDisplay : MonoBehaviour
 
     private CardEntry data;
 
+    private static readonly Dictionary<string, Sprite> iconCache = new();
+
     public void Initialize(CardEntry entry)
     {
         data = entry;
@@ -25,7 +28,13 @@ public class CardDisplay : MonoBehaviour
         leftValueText.text = entry.leftValue.ToString();
         rightValueText.text = entry.rightValue.ToString();
 
-        Sprite icon = Resources.Load<Sprite>($"CardIcons/{entry.type}");
+        if (!iconCache.TryGetValue(entry.type, out Sprite icon))
+        {
+            icon = Resources.Load<Sprite>($"CardIcons/{entry.type}");
+            if (icon != null)
+                iconCache[entry.type] = icon;
+        }
+
         if (icon != null)
         {
             typeIcon.sprite = icon;

--- a/Assets/Scripts/DeckManager.cs
+++ b/Assets/Scripts/DeckManager.cs
@@ -8,15 +8,21 @@ public class DeckManager : MonoBehaviour
     public Transform spawnPoint;
     public Transform handAreaTransform;
 
+    [SerializeField] private TextAsset cardDataAsset;
+
     public List<CardEntry> fullDeck = new();
     private Stack<CardEntry> drawPile = new();
+    private HandLayoutFanStyle handLayout;
 
     public void LoadDeckFromJson()
     {
-        TextAsset jsonFile = Resources.Load<TextAsset>("sabodeus_card_data");
+        TextAsset jsonFile = cardDataAsset;
+        if (jsonFile == null)
+            jsonFile = Resources.Load<TextAsset>("sabodeus_card_data");
+
         if (jsonFile == null)
         {
-            Debug.LogError("JSON file not found in Resources folder!");
+            Debug.LogError("JSON file not found!");
             return;
         }
 
@@ -77,20 +83,16 @@ public class DeckManager : MonoBehaviour
             Debug.LogWarning("CardDisplay script not found on prefab.");
 
         // 🔄 Fan stili dizilim için doğru scripti çağır
-        var layout = handAreaTransform.GetComponent<HandLayoutFanStyle>();
-        if (layout != null)
-            layout.UpdateLayout();
+        if (handLayout != null)
+            handLayout.UpdateLayout();
 
         return cardData;
     }
 
     private void Start()
     {
+        handLayout = handAreaTransform.GetComponent<HandLayoutFanStyle>();
         LoadDeckFromJson();
-
-        TextAsset jsonFile = Resources.Load<TextAsset>("sabodeus_card_data");
-        Debug.Log("Yüklenen JSON içeriği:\n" + jsonFile.text);
-
         InitializeDrawPile();
 
         var cardData = SpawnCardToHand();

--- a/Assets/Scripts/RelayManager.cs
+++ b/Assets/Scripts/RelayManager.cs
@@ -14,6 +14,8 @@ public class RelayManager : MonoBehaviour
     public UnityEvent<string> OnRelayCreated;
     public int maxPlayers = 4;
 
+    [SerializeField] private JoinAndCreateUI cachedUI;
+
     private NetworkManager netManager;
     private UnityTransport transport;
 
@@ -22,6 +24,8 @@ public class RelayManager : MonoBehaviour
         await Initialize();
         netManager = NetworkManager.Singleton;
         transport = netManager?.NetworkConfig.NetworkTransport as UnityTransport;
+        if (cachedUI == null)
+            cachedUI = FindObjectOfType<JoinAndCreateUI>();
     }
 
     private async Task Initialize()
@@ -113,9 +117,11 @@ public class RelayManager : MonoBehaviour
 
     private void ShowFullRoomWarning()
     {
-        var ui = FindObjectOfType<JoinAndCreateUI>();
-        if (ui?.fullRoomWarning != null)
-            ui.fullRoomWarning.SetActive(true);
+        if (cachedUI == null)
+            cachedUI = FindObjectOfType<JoinAndCreateUI>();
+
+        if (cachedUI?.fullRoomWarning != null)
+            cachedUI.fullRoomWarning.SetActive(true);
         else
             Debug.LogWarning("Uyarı kutusu bulunamadı.");
     }


### PR DESCRIPTION
## Summary
- cache sprites in `CardDisplay`
- allow `DeckManager` to load card data from an assigned asset
- cache UI lookup in `RelayManager`

## Testing
- `dotnet format --verify-no-changes` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68549894cda88322bf6ba8f9296b4837