### PR TITLE
Integrate runtime localization with settings menu

### DIFF
--- a/Assets/Scripts/CardDisplay.cs
+++ b/Assets/Scripts/CardDisplay.cs
@@ -17,13 +17,21 @@ public class CardDisplay : MonoBehaviour
 
     private static readonly Dictionary<string, Sprite> iconCache = new();
 
+    private void OnEnable()
+    {
+        LocalizationManager.OnLanguageChanged += UpdateLocalization;
+    }
+
+    private void OnDisable()
+    {
+        LocalizationManager.OnLanguageChanged -= UpdateLocalization;
+    }
+
     public void Initialize(CardEntry entry)
     {
         data = entry;
 
-        // Localization
-        nameText.text = LocalizationManager.Get(entry.nameKey);
-        descriptionText.text = LocalizationManager.Get(entry.descriptionKey);
+        UpdateLocalization();
 
         leftValueText.text = entry.leftValue.ToString();
         rightValueText.text = entry.rightValue.ToString();
@@ -45,6 +53,15 @@ public class CardDisplay : MonoBehaviour
             Debug.LogWarning($"[CardDisplay] Icon not found for type: {entry.type}");
             typeIcon.enabled = false;
         }
+    }
+
+    private void UpdateLocalization()
+    {
+        if (data == null)
+            return;
+
+        nameText.text = LocalizationManager.Get(data.nameKey);
+        descriptionText.text = LocalizationManager.Get(data.descriptionKey);
     }
 
     public CardEntry GetData() => data;

--- a/Assets/Scripts/LocalizationManager.cs
+++ b/Assets/Scripts/LocalizationManager.cs
@@ -3,29 +3,83 @@ using UnityEngine;
 
 public static class LocalizationManager
 {
-    // Test ama�l� yerelle�tirme s�zl���
-    private static Dictionary<string, string> dummyLocalization = new Dictionary<string, string>()
+    public static event System.Action OnLanguageChanged;
+
+    private static string currentLanguage = "en";
+
+    private static readonly Dictionary<string, Dictionary<string, string>> localization = new()
     {
-        { "card.bridge.name", "Bridge" },
-        { "card.bridge.desc", "Allows flexible placement." },
-
-        { "card.nuclear.name", "Nuclear Plant" },
-        { "card.nuclear.desc", "Destroy any completed pair." },
-
-        { "card.factory.name", "Factory" },
-        { "card.factory.desc", "Grants a skill card when completed." },
-
-        { "card.castle.name", "Castle" },
-        { "card.castle.desc", "Doubles score of structures between it and city center." },
-
-        { "card.port.name", "Port" },
-        { "card.port.desc", "Can be sabotaged without being completed." }
+        ["en"] = new Dictionary<string, string>
+        {
+            { "card.bridge.name", "Bridge" },
+            { "card.bridge.desc", "Allows flexible placement." },
+            { "card.nuclear.name", "Nuclear Plant" },
+            { "card.nuclear.desc", "Destroy any completed pair." },
+            { "card.factory.name", "Factory" },
+            { "card.factory.desc", "Grants a skill card when completed." },
+            { "card.castle.name", "Castle" },
+            { "card.castle.desc", "Doubles score of structures between it and city center." },
+            { "card.port.name", "Port" },
+            { "card.port.desc", "Can be sabotaged without being completed." }
+        },
+        ["tr"] = new Dictionary<string, string>
+        {
+            { "card.bridge.name", "Köprü" },
+            { "card.bridge.desc", "Esnek yerleşime izin verir." },
+            { "card.nuclear.name", "Nükleer Santral" },
+            { "card.nuclear.desc", "Tamamlanan herhangi bir çifti yok eder." },
+            { "card.factory.name", "Fabrika" },
+            { "card.factory.desc", "Tamamlandığında bir yetenek kartı verir." },
+            { "card.castle.name", "Kale" },
+            { "card.castle.desc", "Şehir merkezine kadar olan yapıları iki katı puanlar." },
+            { "card.port.name", "Liman" },
+            { "card.port.desc", "Tamamlanmadan sabotaj yapılabilir." }
+        },
+        ["fr"] = new Dictionary<string, string>
+        {
+            { "card.bridge.name", "Pont" },
+            { "card.bridge.desc", "Permet une pose flexible." },
+            { "card.nuclear.name", "Centrale Nucléaire" },
+            { "card.nuclear.desc", "Détruit n'importe quelle paire complétée." },
+            { "card.factory.name", "Usine" },
+            { "card.factory.desc", "Donne une carte compétence une fois terminée." },
+            { "card.castle.name", "Château" },
+            { "card.castle.desc", "Double le score des structures jusqu'au centre-ville." },
+            { "card.port.name", "Port" },
+            { "card.port.desc", "Peut être saboté sans être complété." }
+        },
+        ["zh"] = new Dictionary<string, string>
+        {
+            { "card.bridge.name", "桥梁" },
+            { "card.bridge.desc", "允许灵活放置。" },
+            { "card.nuclear.name", "核电站" },
+            { "card.nuclear.desc", "摧毁任何已完成的组合。" },
+            { "card.factory.name", "工厂" },
+            { "card.factory.desc", "完成时获得技能牌。" },
+            { "card.castle.name", "城堡" },
+            { "card.castle.desc", "使其与城市中心之间建筑得分翻倍。" },
+            { "card.port.name", "港口" },
+            { "card.port.desc", "未完成也可被破坏。" }
+        }
     };
+
+    public static void SetLanguage(string code)
+    {
+        if (localization.ContainsKey(code))
+        {
+            currentLanguage = code;
+            OnLanguageChanged?.Invoke();
+        }
+        else
+        {
+            Debug.LogWarning($"Unsupported language: {code}");
+        }
+    }
 
     public static string Get(string key)
     {
-        if (dummyLocalization.ContainsKey(key))
-            return dummyLocalization[key];
+        if (localization.TryGetValue(currentLanguage, out var dict) && dict.TryGetValue(key, out var value))
+            return value;
 
         Debug.LogWarning("Localization key not found: " + key);
         return key; // fallback

--- a/Assets/Scripts/LocalizedText.cs
+++ b/Assets/Scripts/LocalizedText.cs
@@ -1,0 +1,27 @@
+using TMPro;
+using UnityEngine;
+
+[RequireComponent(typeof(TMP_Text))]
+public class LocalizedText : MonoBehaviour
+{
+    public string key;
+    private TMP_Text text;
+
+    private void Awake()
+    {
+        text = GetComponent<TMP_Text>();
+        LocalizationManager.OnLanguageChanged += UpdateText;
+        UpdateText();
+    }
+
+    private void OnDestroy()
+    {
+        LocalizationManager.OnLanguageChanged -= UpdateText;
+    }
+
+    private void UpdateText()
+    {
+        if (text != null)
+            text.text = LocalizationManager.Get(key);
+    }
+}

--- a/Assets/Scripts/LocalizedText.cs.meta
+++ b/Assets/Scripts/LocalizedText.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f88470c698940d7b8fe59909216b022
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/SettingsMenuRuntime.cs
+++ b/Assets/Scripts/SettingsMenuRuntime.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.SceneManagement;
+
+public class SettingsMenuRuntime : MonoBehaviour
+{
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    private static void Init()
+    {
+        SceneManager.sceneLoaded += OnSceneLoaded;
+    }
+
+    private static void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        var menu = GameObject.Find("SettingsMenu");
+        var settingsButton = GameObject.Find("Settings")?.GetComponent<Button>();
+        var backButton = menu?.transform.Find("Back")?.GetComponent<Button>();
+
+        if (menu == null || settingsButton == null || backButton == null)
+            return;
+
+        menu.SetActive(false);
+        settingsButton.onClick.AddListener(() => menu.SetActive(true));
+        backButton.onClick.AddListener(() => menu.SetActive(false));
+
+        var buttons = menu.GetComponentsInChildren<Button>(true);
+        if (buttons.Length >= 5)
+        {
+            buttons[0].onClick.AddListener(() => LocalizationManager.SetLanguage("tr"));
+            buttons[1].onClick.AddListener(() => LocalizationManager.SetLanguage("en"));
+            buttons[2].onClick.AddListener(() => LocalizationManager.SetLanguage("fr"));
+            buttons[3].onClick.AddListener(() => LocalizationManager.SetLanguage("zh"));
+        }
+    }
+}

--- a/Assets/Scripts/SettingsMenuRuntime.cs.meta
+++ b/Assets/Scripts/SettingsMenuRuntime.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f535d5098cbf43b6937bf910ce77ab26
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- expand `LocalizationManager` with multi-language support
- add `LocalizedText` component for automatic text updates
- update `CardDisplay` to refresh when language changes
- provide `SettingsMenuRuntime` to wire up Settings UI at runtime

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68549a246fac8322b583d72d6624eeb8