### PR TITLE
Switch city slots to 3D

### DIFF
--- a/Assets/Scripts/SlotController.cs
+++ b/Assets/Scripts/SlotController.cs
@@ -1,25 +1,24 @@
 using UnityEngine;
-using UnityEngine.UI;
 using UnityEngine.EventSystems;
 
 public class SlotController : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
 {
     public bool IsRightSide { get; private set; }
     public int Index { get; private set; }
-    public Image image;
+    public SpriteRenderer spriteRenderer;
 
     private CityAreaManager manager;
     private Color originalColor;
-    [SerializeField] private Color highlightColor = new Color(1f, 1f, 0.5f, 1f); // Açýk sarý
-    public bool isOccupied { get; private set; } = false;
-    public GameObject CurrentCard { get; private set; }
+    public void Initialize(CityAreaManager mgr, bool rightSide, int index, SpriteRenderer img)
+        spriteRenderer = img;
+        originalColor = spriteRenderer != null ? spriteRenderer.color : Color.white;
 
-    public void Initialize(CityAreaManager mgr, bool rightSide, int index, Image img)
-    {
-        manager = mgr;
-        IsRightSide = rightSide;
-        Index = index;
-        image = img;
+        if (spriteRenderer != null)
+            spriteRenderer.color = originalColor;
+        if (isOccupied || spriteRenderer == null) return;
+        spriteRenderer.color = highlightColor;
+        if (spriteRenderer == null) return;
+        spriteRenderer.color = originalColor;
         originalColor = image != null ? image.color : Color.white;
     }
 


### PR DESCRIPTION
## Summary
- update `SlotController` to work with SpriteRenderers instead of UI Images
- convert `CityAreaManager` to create 3D sprite slots with box colliders
- ensure a `PhysicsRaycaster` is available so pointer events reach 3D objects

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854a7adfb808322b3b604156c028244