### PR TITLE
Implement slot restrictions and progression logic

### DIFF
--- a/Assets/Scripts/CardDraggable.cs
+++ b/Assets/Scripts/CardDraggable.cs
@@ -99,7 +99,7 @@ public class CardDraggable : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
         if (eventData.pointerEnter != null)
         {
             SlotController slot = eventData.pointerEnter.GetComponent<SlotController>();
-            if (slot != null && !slot.isOccupied)
+            if (slot != null && slot.CanPlaceCard(gameObject))
             {
                 transform.SetParent(slot.transform, true);
                 transform.localPosition = Vector3.zero;

--- a/Assets/Scripts/SlotController.cs
+++ b/Assets/Scripts/SlotController.cs
@@ -16,6 +16,13 @@ public class SlotController : MonoBehaviour, IPointerEnterHandler, IPointerExitH
     private Color originalColor;
     private Renderer slotRenderer;
 
+    public string AllowedType { get; private set; } = null;
+
+    public void SetAllowedType(string type)
+    {
+        AllowedType = type;
+    }
+
     public void Initialize(CityAreaManager mgr, bool rightSide, int index, Renderer rend)
     {
         manager = mgr;
@@ -28,6 +35,12 @@ public class SlotController : MonoBehaviour, IPointerEnterHandler, IPointerExitH
         {
             originalColor = slotRenderer.material.color;
         }
+    }
+
+    public bool CanPlaceCard(GameObject card)
+    {
+        if (isOccupied) return false;
+        return manager == null || manager.CanPlaceCard(this, card);
     }
 
     public void AssignCard(GameObject card)


### PR DESCRIPTION
## Summary
- add allowed type support for slot placement
- restrict slots after building placement in CityAreaManager
- prevent dragging cards to invalid slots

## Testing
- `dotnet build Sabodeus.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd0b917d08322af1fe9a0463a1607