### PR TITLE
Fix slot border display when card present

### DIFF
--- a/Assets/Scripts/SlotController.cs
+++ b/Assets/Scripts/SlotController.cs
@@ -77,6 +77,12 @@ public class SlotController : MonoBehaviour, IPointerEnterHandler, IPointerExitH
         if (slotRenderer == null)
             return;
 
+        if (isOccupied)
+        {
+            slotRenderer.enabled = false;
+            return;
+        }
+
         if (card == null)
         {
             slotRenderer.enabled = false;


### PR DESCRIPTION
## Summary
- prevent showing slot border if a card has already been placed

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685fd66bb5f083229b8031c45165a622