### PR TITLE
Implement graveyard stacking and deck refresh

### DIFF
--- a/Assets/Scripts/CardDeckVisual.cs
+++ b/Assets/Scripts/CardDeckVisual.cs
@@ -4,13 +4,21 @@ using UnityEngine.EventSystems;
 public class CardDeckVisual : MonoBehaviour, IPointerClickHandler
 {
     public DeckManager deckManager;
+    public GraveyardVisual graveyard;
 
     public void OnPointerClick(PointerEventData eventData)
     {
-        if (deckManager != null)
+        if (deckManager == null)
+            return;
+
+        if (deckManager.RemainingCards == 0 && graveyard != null)
         {
-            var card = deckManager.SpawnCardToHand();
-            Debug.Log("Kart çekildi: " + card?.id);
+            var entries = graveyard.ClearCards();
+            if (entries.Count > 0)
+                deckManager.ReplenishDeck(entries);
         }
+
+        var card = deckManager.SpawnCardToHand();
+        Debug.Log("Kart ekildi: " + card?.id);
     }
 }

--- a/Assets/Scripts/CardDraggable.cs
+++ b/Assets/Scripts/CardDraggable.cs
@@ -133,6 +133,19 @@ public class CardDraggable : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
                     cardCanvas.sortingOrder = CityAreaManager.Instance.baseSortingOrder - slot.Index;
                 return;
             }
+
+            GraveyardVisual gy = eventData.pointerEnter.GetComponent<GraveyardVisual>();
+            if (gy == null)
+                gy = eventData.pointerEnter.GetComponentInParent<GraveyardVisual>();
+            if (gy != null)
+            {
+                gy.AddCard(gameObject);
+                layout?.UpdateLayout();
+                CardPreviewManager.Instance?.HidePreview();
+                CityAreaManager.Instance?.ShowSlotBorders(null);
+                DraggedCard = null;
+                return;
+            }
         }
 
         // Uygun slot yok → eski konuma dön

--- a/Assets/Scripts/DeckManager.cs
+++ b/Assets/Scripts/DeckManager.cs
@@ -114,6 +114,18 @@ public class DeckManager : MonoBehaviour
             (list[k], list[n]) = (list[n], list[k]);
         }
     }
+
+    public void ReplenishDeck(IEnumerable<CardEntry> cards)
+    {
+        if (cards == null)
+            return;
+        List<CardEntry> list = new(cards);
+        if (list.Count == 0)
+            return;
+        Shuffle(list);
+        drawPile = new Stack<CardEntry>(list);
+        Debug.Log($"Draw pile replenished with {drawPile.Count} cards from graveyard.");
+    }
 }
 
 [System.Serializable]

--- a/Assets/Scripts/GraveyardVisual.cs
+++ b/Assets/Scripts/GraveyardVisual.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GraveyardVisual : MonoBehaviour
+{
+    public float stackOffset = 0.01f;
+    private readonly List<GameObject> _cards = new();
+
+    public void AddCard(GameObject card)
+    {
+        if (card == null) return;
+        _cards.Add(card);
+        card.transform.SetParent(transform, true);
+        card.transform.localRotation = Quaternion.identity;
+        card.transform.localPosition = new Vector3(0, 0, -stackOffset * _cards.Count);
+        var drag = card.GetComponent<CardDraggable>();
+        if (drag != null)
+            Destroy(drag);
+    }
+
+    public List<CardEntry> ClearCards()
+    {
+        List<CardEntry> entries = new();
+        foreach (var c in _cards)
+        {
+            var disp = c.GetComponent<CardDisplay>();
+            if (disp != null)
+                entries.Add(disp.GetData());
+            Destroy(c);
+        }
+        _cards.Clear();
+        return entries;
+    }
+}


### PR DESCRIPTION
## Summary
- allow dragging cards onto `GraveyardVisual` where they stack
- add `GraveyardVisual` class to manage stacked cards
- when deck is empty, refill it from `GraveyardVisual`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685fec700d448322b29b7fff75ca7aec