### PR TITLE
Improve deck animation and card hover

### DIFF
--- a/Assets/Scripts/CardDeckVisual.cs
+++ b/Assets/Scripts/CardDeckVisual.cs
@@ -25,7 +25,7 @@ public class CardDeckVisual : MonoBehaviour, IPointerClickHandler
                 deckManager.ReplenishDeck(entries);
         }
 
-        var card = deckManager.SpawnCardToHand();
+        var card = deckManager.SpawnCardToHandAnimated(transform);
         Debug.Log("Kart ekildi: " + card?.id);
         UpdateCountText();
     }

--- a/Assets/Scripts/CardDraggable.cs
+++ b/Assets/Scripts/CardDraggable.cs
@@ -22,6 +22,22 @@ public class CardDraggable : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
     public float hoverForward = 2f;
     private bool isHovered = false;
 
+    private void SetSiblingOpacity(float alpha, bool blockRaycast)
+    {
+        Transform parent = transform.parent;
+        if (parent == null) return;
+
+        foreach (Transform child in parent)
+        {
+            if (child == transform) continue;
+            CanvasGroup cg = child.GetComponent<CanvasGroup>();
+            if (cg == null)
+                cg = child.gameObject.AddComponent<CanvasGroup>();
+            cg.alpha = alpha;
+            cg.blocksRaycasts = blockRaycast;
+        }
+    }
+
     void Start()
     {
         cam = Camera.main;
@@ -47,6 +63,7 @@ public class CardDraggable : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
         CardPreviewManager.Instance?.ShowPreview(gameObject);
         HoveredCard = gameObject;
         CityAreaManager.Instance?.ShowSlotBorders(gameObject);
+        SetSiblingOpacity(0.5f, false);
     }
 
     public void OnPointerExit(PointerEventData eventData)
@@ -57,6 +74,7 @@ public class CardDraggable : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
         CardPreviewManager.Instance?.HidePreview();
         HoveredCard = null;
         CityAreaManager.Instance?.ShowSlotBorders(null);
+        SetSiblingOpacity(1f, true);
     }
 
     public void OnPointerDown(PointerEventData eventData)
@@ -64,6 +82,7 @@ public class CardDraggable : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
         isDragging = true;
         isHovered = false;
         CardPreviewManager.Instance?.HidePreview();
+        SetSiblingOpacity(1f, true);
         originalParent = transform.parent;
 
         // If this card was sitting in a slot, clear that slot so it can accept
@@ -122,6 +141,7 @@ public class CardDraggable : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
             canvasGroup.blocksRaycasts = true;
         if (cardCollider != null)
             cardCollider.enabled = true;
+        SetSiblingOpacity(1f, true);
 
         // 💡 Daha sağlam yöntem: pointerEnter üzerinden slotı bul
         if (eventData.pointerEnter != null)

--- a/Assets/Scripts/DeckManager.cs
+++ b/Assets/Scripts/DeckManager.cs
@@ -92,12 +92,15 @@ public class DeckManager : MonoBehaviour
         return cardData;
     }
 
-    private IEnumerator SpawnCardToHandAnimated(CardEntry cardData)
+    private IEnumerator SpawnCardToHandAnimatedRoutine(CardEntry cardData, Transform startPoint)
     {
         if (handAreaTransform.childCount >= 4 || cardData == null)
             yield break;
 
-        GameObject cardObj = Instantiate(cardPrefab, spawnPoint.position, Quaternion.identity, spawnPoint.parent);
+        if (startPoint == null)
+            startPoint = spawnPoint;
+
+        GameObject cardObj = Instantiate(cardPrefab, startPoint.position, Quaternion.identity, startPoint.parent);
         cardObj.transform.localScale = Vector3.one * (0.8f / 3f);
 
         var display = cardObj.GetComponent<CardDisplay>();
@@ -114,7 +117,7 @@ public class DeckManager : MonoBehaviour
             display.typeIcon.enabled = false;
         }
 
-        Vector3 startPos = spawnPoint.position;
+        Vector3 startPos = startPoint.position;
         Vector3 endPos = handAreaTransform.position;
         float t = 0f;
         while (t < 1f)
@@ -140,6 +143,30 @@ public class DeckManager : MonoBehaviour
 
         if (handLayout != null)
             handLayout.UpdateLayout();
+    }
+
+    public CardEntry SpawnCardToHandAnimated(Transform startPoint)
+    {
+        if (handAreaTransform.childCount >= 4)
+        {
+            Debug.Log("Hand is full. Max 4 cards allowed.");
+            return null;
+        }
+
+        var cardData = DrawCard();
+        if (cardData == null)
+        {
+            Debug.LogWarning("No card to draw.");
+            return null;
+        }
+
+        StartCoroutine(SpawnCardToHandAnimatedRoutine(cardData, startPoint));
+        return cardData;
+    }
+
+    private IEnumerator SpawnCardToHandAnimated(CardEntry cardData)
+    {
+        return SpawnCardToHandAnimatedRoutine(cardData, spawnPoint);
     }
 
     private IEnumerator DealStartingHand(int count)


### PR DESCRIPTION
## Summary
- animate cards from the deck object when drawing
- dim other cards while hovering one in hand

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ffd0fb3488322896af2a24bdd5cb4