### PR TITLE
Fix building card icon reference

### DIFF
--- a/Assets/Prefabs/CardPrefab.prefab
+++ b/Assets/Prefabs/CardPrefab.prefab
@@ -921,7 +921,7 @@ MonoBehaviour:
   descriptionText: {fileID: 8191643813607936820}
   leftValueText: {fileID: 7645800118749853484}
   rightValueText: {fileID: 2161351754430182456}
-  typeIcon: {fileID: 1171927279314227061}
+  typeIcon: {fileID: 3940572274030972432}
 --- !u!114 &2656065775334608559
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Summary
- fix `CardDisplay` prefab reference so `typeIcon` uses the DescriptionImage object

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68600a8234c48322be78d73ccc45c57a