### PR TITLE
Fix card icon placement

### DIFF
--- a/Assets/Prefabs/CardPrefab.prefab
+++ b/Assets/Prefabs/CardPrefab.prefab
@@ -921,7 +921,7 @@ MonoBehaviour:
   descriptionText: {fileID: 8191643813607936820}
   leftValueText: {fileID: 7645800118749853484}
   rightValueText: {fileID: 2161351754430182456}
-  typeIcon: {fileID: 3940572274030972432}
+  typeIcon: {fileID: 1171927279314227061}
 --- !u!114 &2656065775334608559
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Summary
- correct typeIcon reference to use `CardBackground` image instead of `DescriptionImage`

## Testing
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68600ec34cd88322a38716ab39b7c6b5