### PR TITLE
Enable hover spread for card hand area

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Assets\Scripts\GraveyardVisual.cs" />
     <Compile Include="Assets\Scripts\ExitGameHandler.cs" />
     <Compile Include="Assets\Scripts\CardDraggable.cs" />
+    <Compile Include="Assets\Scripts\HandAreaHoverSpread.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Assets\TextMesh Pro\Shaders\TMPro.cginc" />

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -4152,6 +4152,7 @@ GameObject:
   - component: {fileID: 1065721744}
   - component: {fileID: 1065721746}
   - component: {fileID: 1065721745}
+  - component: {fileID: 1468752447}
   m_Layer: 5
   m_Name: Image
   m_TagString: Untagged
@@ -4216,6 +4217,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1065721743}
   m_CullTransparentMesh: 1
+--- !u!114 &1468752447
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1065721743}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3185030fef6f4302a7a84de3c6d9d549, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!1 &1067200575
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/HandAreaHoverSpread.cs
+++ b/Assets/Scripts/HandAreaHoverSpread.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+[RequireComponent(typeof(HandLayoutFanStyle))]
+public class HandAreaHoverSpread : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
+{
+    private HandLayoutFanStyle layout;
+
+    private void Awake()
+    {
+        layout = GetComponent<HandLayoutFanStyle>();
+    }
+
+    public void OnPointerEnter(PointerEventData eventData)
+    {
+        layout?.SpreadOut();
+    }
+
+    public void OnPointerExit(PointerEventData eventData)
+    {
+        layout?.Restore();
+    }
+}
+

--- a/Assets/Scripts/HandAreaHoverSpread.cs.meta
+++ b/Assets/Scripts/HandAreaHoverSpread.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3185030fef6f4302a7a84de3c6d9d549
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add `HandAreaHoverSpread` script that triggers `HandLayoutFanStyle` spread on pointer enter
- register new script in project
- attach script to the hand area image in SampleScene

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68601658c91c8322b3d66e90f1009707