### PR TITLE
Add screen-based preview placement

### DIFF
--- a/Assets/Scripts/CardPreviewManager.cs
+++ b/Assets/Scripts/CardPreviewManager.cs
@@ -5,7 +5,18 @@ public class CardPreviewManager : MonoBehaviour
     public static CardPreviewManager Instance { get; private set; }
 
     [Header("Preview Settings")]
+    [Tooltip("World position used when 'useScreenPosition' is disabled")]
     public Vector3 previewPosition = Vector3.zero;
+
+    [Tooltip("Normalized screen position (Viewport space) where the preview will appear")] 
+    public Vector2 previewScreenPosition = new Vector2(0.5f, 0.5f);
+
+    [Tooltip("Distance from the camera when using screen position")] 
+    public float previewDepth = 2f;
+
+    [Tooltip("If true previewScreenPosition is used to place the preview")] 
+    public bool useScreenPosition = false;
+
     public float previewScale = 0.7f;
 
     private GameObject currentPreview;
@@ -26,7 +37,13 @@ public class CardPreviewManager : MonoBehaviour
     public void ShowPreview(GameObject card)
     {
         HidePreview();
-        currentPreview = Instantiate(card, previewPosition, Quaternion.identity);
+        Vector3 spawnPos = previewPosition;
+        if (useScreenPosition && Camera.main != null)
+        {
+            Vector3 viewportPos = new Vector3(previewScreenPosition.x, previewScreenPosition.y, previewDepth);
+            spawnPos = Camera.main.ViewportToWorldPoint(viewportPos);
+        }
+        currentPreview = Instantiate(card, spawnPos, Quaternion.identity);
         foreach (var drag in currentPreview.GetComponentsInChildren<CardDraggable>(true))
             Destroy(drag);
         foreach (var col in currentPreview.GetComponentsInChildren<Collider>(true))


### PR DESCRIPTION
## Summary
- allow placing card previews using normalized screen coordinates
- add fields for screen position, depth, and toggle to CardPreviewManager

## Testing
- `echo "No tests to run"`

------
https://chatgpt.com/codex/tasks/task_e_68601fb155948322976d7e9a5b4f7ae2