### PR TITLE
Add configurable CardPreview settings via ScriptableObject

### DIFF
--- a/Assets/Resources/CardPreviewSettings.asset
+++ b/Assets/Resources/CardPreviewSettings.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ede1c511fc594452b9a7149504120510, type: 3}
+  m_Name: CardPreviewSettings
+  m_EditorClassIdentifier: 
+  previewPosition: {x: 0, y: 0, z: 0}
+  previewScreenPosition: {x: 0.5, y: 0.5}
+  previewDepth: 2
+  useScreenPosition: 0
+  previewScale: 0.7

--- a/Assets/Resources/CardPreviewSettings.asset.meta
+++ b/Assets/Resources/CardPreviewSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e42c074b-f750-481d-9f8c-0612e33b5f8b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/CardPreviewManager.cs
+++ b/Assets/Scripts/CardPreviewManager.cs
@@ -4,20 +4,8 @@ public class CardPreviewManager : MonoBehaviour
 {
     public static CardPreviewManager Instance { get; private set; }
 
-    [Header("Preview Settings")]
-    [Tooltip("World position used when 'useScreenPosition' is disabled")]
-    public Vector3 previewPosition = Vector3.zero;
-
-    [Tooltip("Normalized screen position (Viewport space) where the preview will appear")] 
-    public Vector2 previewScreenPosition = new Vector2(0.5f, 0.5f);
-
-    [Tooltip("Distance from the camera when using screen position")] 
-    public float previewDepth = 2f;
-
-    [Tooltip("If true previewScreenPosition is used to place the preview")] 
-    public bool useScreenPosition = false;
-
-    public float previewScale = 0.7f;
+    [Tooltip("Settings asset used for preview parameters")]
+    public CardPreviewSettings settings;
 
     private GameObject currentPreview;
 
@@ -32,12 +20,19 @@ public class CardPreviewManager : MonoBehaviour
     private void Awake()
     {
         Instance = this;
+        if (settings == null)
+            settings = Resources.Load<CardPreviewSettings>("CardPreviewSettings");
     }
 
     public void ShowPreview(GameObject card)
     {
         HidePreview();
-        Vector3 spawnPos = previewPosition;
+        Vector3 spawnPos = settings != null ? settings.previewPosition : Vector3.zero;
+        bool useScreenPosition = settings != null && settings.useScreenPosition;
+        Vector2 previewScreenPosition = settings != null ? settings.previewScreenPosition : new Vector2(0.5f, 0.5f);
+        float previewDepth = settings != null ? settings.previewDepth : 2f;
+        float previewScale = settings != null ? settings.previewScale : 0.7f;
+
         if (useScreenPosition && Camera.main != null)
         {
             Vector3 viewportPos = new Vector3(previewScreenPosition.x, previewScreenPosition.y, previewDepth);

--- a/Assets/Scripts/CardPreviewSettings.cs
+++ b/Assets/Scripts/CardPreviewSettings.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "CardPreviewSettings", menuName = "ScriptableObjects/CardPreviewSettings")]
+public class CardPreviewSettings : ScriptableObject
+{
+    [Header("Preview Settings")]
+    [Tooltip("World position used when 'useScreenPosition' is disabled")]
+    public Vector3 previewPosition = Vector3.zero;
+
+    [Tooltip("Normalized screen position (Viewport space) where the preview will appear")]
+    public Vector2 previewScreenPosition = new Vector2(0.5f, 0.5f);
+
+    [Tooltip("Distance from the camera when using screen position")]
+    public float previewDepth = 2f;
+
+    [Tooltip("If true previewScreenPosition is used to place the preview")]
+    public bool useScreenPosition = false;
+
+    public float previewScale = 0.7f;
+}

--- a/Assets/Scripts/CardPreviewSettings.cs.meta
+++ b/Assets/Scripts/CardPreviewSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ede1c511-fc59-4452-b9a7-149504120510
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- create `CardPreviewSettings` ScriptableObject so preview parameters can be edited in the Unity editor
- load this settings asset from `Resources` in `CardPreviewManager`
- update preview logic to use values from the settings asset
- include default asset under `Assets/Resources`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686044104ae8832288fe2766b4ad1b1b