### PR TITLE
Fix debug message in ExitGameHandler

### DIFF
--- a/Assets/Scripts/ExitGameHandler.cs
+++ b/Assets/Scripts/ExitGameHandler.cs
@@ -7,7 +7,7 @@ public class ExitGameHandler : MonoBehaviour
 {
     public void ExitGame()
     {
-        Debug.Log("Çýkýþ yapýlýyor...");
+        Debug.Log("Ã‡Ä±kÄ±ÅŸ yapÄ±lÄ±yor...");
 
 #if UNITY_EDITOR
         EditorApplication.isPlaying = false;


### PR DESCRIPTION
## Summary
- localize exit log text for player feedback

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860486141388322ae569e46315364eb