### PR TITLE
Remove BOM from C# scripts

### DIFF
--- a/Assets/Scripts/CardDraggable.cs
+++ b/Assets/Scripts/CardDraggable.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using UnityEngine.EventSystems;
 
 public class CardDraggable : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, IPointerDownHandler, IDragHandler, IPointerUpHandler

--- a/Assets/Scripts/DeckManager.cs
+++ b/Assets/Scripts/DeckManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 

--- a/Assets/Scripts/JoinAndCreateUI.cs
+++ b/Assets/Scripts/JoinAndCreateUI.cs
@@ -1,4 +1,4 @@
-﻿using TMPro;
+using TMPro;
 using Unity.Netcode;
 using UnityEngine;
 using System.Collections.Generic;

--- a/Assets/Scripts/JoinGameManager.cs
+++ b/Assets/Scripts/JoinGameManager.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 using TMPro;
 
 public class JoinGameManager : MonoBehaviour

--- a/Assets/Scripts/LobbyPlayerListManager.cs
+++ b/Assets/Scripts/LobbyPlayerListManager.cs
@@ -1,4 +1,4 @@
-﻿using Unity.Netcode;
+using Unity.Netcode;
 using UnityEngine;
 
 public class LobbyPlayerListManager : NetworkBehaviour

--- a/Assets/Scripts/LobbyPlayerListUI.cs
+++ b/Assets/Scripts/LobbyPlayerListUI.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using UnityEngine;
 using TMPro;
 using Unity.Netcode;

--- a/Assets/Scripts/RelayManager.cs
+++ b/Assets/Scripts/RelayManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Unity.Netcode;
 using Unity.Netcode.Transports.UTP;
 using Unity.Networking.Transport.Relay;


### PR DESCRIPTION
## Summary
- convert several Unity C# scripts to plain UTF-8 (no BOM)

## Testing
- `python3 - <<'PY'
for path in ['Assets/Scripts/RelayManager.cs','Assets/Scripts/CardDraggable.cs','Assets/Scripts/DeckManager.cs','Assets/Scripts/JoinGameManager.cs','Assets/Scripts/LobbyPlayerListManager.cs','Assets/Scripts/JoinAndCreateUI.cs','Assets/Scripts/LobbyPlayerListUI.cs']:
    with open(path,'rb') as f:
        print(path, f.read(3))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6860486612e883229992863957099ca6