### PR TITLE
Implement city scoring display

### DIFF
--- a/Assets/Scripts/CardDraggable.cs
+++ b/Assets/Scripts/CardDraggable.cs
@@ -113,6 +113,7 @@ public class CardDraggable : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
             if (parentSlot != null)
             {
                 parentSlot.ClearSlot();
+                CityAreaManager.Instance?.UpdateScoreDisplay();
                 transform.SetParent(null, true);
             }
             else if (layout != null && originalParent == layout.transform)
@@ -197,6 +198,7 @@ public class CardDraggable : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
                 CardPreviewManager.Instance?.HidePreview();
                 CityAreaManager.Instance?.ShowSlotBorders(null);
                 DraggedCard = null;
+                CityAreaManager.Instance?.UpdateScoreDisplay();
                 hasDragged = false;
                 return;
             }
@@ -221,5 +223,6 @@ public class CardDraggable : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
         if (cardCanvas != null)
             cardCanvas.sortingOrder = originalSortingOrder;
         hasDragged = false;
+        CityAreaManager.Instance?.UpdateScoreDisplay();
     }
 }

--- a/Assets/Scripts/CityAreaManager.cs
+++ b/Assets/Scripts/CityAreaManager.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using TMPro;
 
 public class CityAreaManager : MonoBehaviour
 {
@@ -13,6 +14,7 @@ public class CityAreaManager : MonoBehaviour
     public int baseSortingOrder = 100;
 
     public Transform slotParent;
+    public TMP_Text scoreText;
 
     private readonly List<SlotController> rightSlots = new();
     private readonly List<SlotController> leftSlots = new();
@@ -23,6 +25,7 @@ public class CityAreaManager : MonoBehaviour
         Instance = this;
         EnsureRaycaster();
         BuildLayout();
+        UpdateScoreDisplay();
     }
 
     private void EnsureRaycaster()
@@ -193,5 +196,41 @@ public class CityAreaManager : MonoBehaviour
                 rightSlots[next].gameObject.SetActive(true);
             }
         }
+
+        UpdateScoreDisplay();
+    }
+
+    public int CalculateScore()
+    {
+        int total = 0;
+        int rows = Mathf.Min(leftSlots.Count, rightSlots.Count);
+        for (int i = 0; i < rows; i++)
+        {
+            int leftVal = 0;
+            if (leftSlots[i].isOccupied)
+            {
+                var disp = leftSlots[i].CurrentCard?.GetComponent<CardDisplay>();
+                if (disp != null)
+                    leftVal = disp.GetData().leftValue;
+            }
+
+            int rightVal = 0;
+            if (rightSlots[i].isOccupied)
+            {
+                var disp = rightSlots[i].CurrentCard?.GetComponent<CardDisplay>();
+                if (disp != null)
+                    rightVal = disp.GetData().rightValue;
+            }
+
+            total += leftVal * rightVal;
+        }
+
+        return total;
+    }
+
+    public void UpdateScoreDisplay()
+    {
+        if (scoreText != null)
+            scoreText.text = CalculateScore().ToString();
     }
 }

--- a/Assets/Scripts/SlotController.cs
+++ b/Assets/Scripts/SlotController.cs
@@ -66,6 +66,8 @@ public class SlotController : MonoBehaviour, IPointerEnterHandler, IPointerExitH
         {
             slotRenderer.enabled = false;
         }
+
+        manager?.UpdateScoreDisplay();
     }
 
     public void OnPointerEnter(PointerEventData eventData) {}


### PR DESCRIPTION
## Summary
- expose a `scoreText` field on `CityAreaManager`
- compute city score from occupied slots
- refresh score when slots change or cards move

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860522927e48322af0454f403738eab