### PR TITLE
Implement networked start and show main menu

### DIFF
--- a/Assets/Scripts/StartGameHandler.cs
+++ b/Assets/Scripts/StartGameHandler.cs
@@ -1,10 +1,21 @@
 using UnityEngine;
+using Unity.Netcode;
 using UnityEngine.SceneManagement;
 
 public class StartGameHandler : MonoBehaviour
 {
     public void StartGame()
     {
-        SceneManager.LoadScene("SampleScene");
+        if (NetworkManager.Singleton != null && NetworkManager.Singleton.IsHost)
+        {
+            NetworkManager.Singleton.SceneManager.LoadScene(
+                "SampleScene",
+                LoadSceneMode.Single);
+        }
+        else
+        {
+            Debug.LogWarning("StartGame called without host authority. Loading locally.");
+            SceneManager.LoadScene("SampleScene");
+        }
     }
 }

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,6 +6,9 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
+    path: Assets/Scenes/MainMenu.unity
+    guid: 0adc3ec5eb83467489095cc1ebda80cf
+  - enabled: 1
     path: Assets/Scenes/SampleScene.unity
     guid: 2cda990e2423bbf4892e6590ba056729
   m_configObjects: {}


### PR DESCRIPTION
## Summary
- make the Start Game button load the play scene for everyone via Netcode
- include MainMenu scene in build settings so the game starts there

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68606b4059348322b9b3263be9e9a3d2