### PR TITLE
Refactor network board spawn logic

### DIFF
--- a/Assets/Scripts/MultiplayerBoardInitializer.cs
+++ b/Assets/Scripts/MultiplayerBoardInitializer.cs
@@ -9,12 +9,20 @@ public class MultiplayerBoardInitializer : NetworkBehaviour
 
     public override void OnNetworkSpawn()
     {
-        if (!IsServer) return;
+        if (!IsServer)
+            return;
 
-        foreach (var client in NetworkManager.Singleton.ConnectedClientsList)
+        var clients = NetworkManager.Singleton.ConnectedClientsList;
+        int count = clients.Count;
+
+        float spacing = Mathf.Abs(playerTwoPosition.x - playerOnePosition.x);
+        float offset = (count - 1) / 2f;
+
+        for (int i = 0; i < count; i++)
         {
+            var client = clients[i];
             ulong clientId = client.ClientId;
-            Vector3 spawnPos = clientId == 0 ? playerOnePosition : playerTwoPosition;
+            Vector3 spawnPos = new Vector3((i - offset) * spacing, playerOnePosition.y, playerOnePosition.z);
 
             GameObject city = Instantiate(cityAreaPrefab, spawnPos, Quaternion.identity);
             city.GetComponent<NetworkObject>().SpawnAsPlayerObject(clientId, true);


### PR DESCRIPTION
## Summary
- spawn city areas for all connected players
- dynamically space spawn positions based on number of clients

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68606ea11ac08322962a62402ac2b47d