### PR TITLE
Fix CardPreviewSettings missing from csproj

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Assets\Scripts\DeckManager.cs" />
     <Compile Include="Assets\Scripts\LocalizedText.cs" />
     <Compile Include="Assets\Scripts\CardPreviewManager.cs" />
+    <Compile Include="Assets\Scripts\CardPreviewSettings.cs" />
     <Compile Include="Assets\Scripts\CardEntry.cs" />
     <Compile Include="Assets\Scripts\CardDeckVisual.cs" />
     <Compile Include="Assets\Scripts\RelayManager.cs" />


### PR DESCRIPTION
## Summary
- include `CardPreviewSettings.cs` in the project

## Testing
- `dotnet build Assembly-CSharp.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68607463f2a48322be244780f4c82630