### PR TITLE
Fix OnDestroy override

### DIFF
--- a/Assets/Scripts/CityAreaManager.cs
+++ b/Assets/Scripts/CityAreaManager.cs
@@ -39,8 +39,9 @@ public class CityAreaManager : NetworkBehaviour
         UpdateScoreDisplay();
     }
 
-    private void OnDestroy()
+    protected override void OnDestroy()
     {
+        base.OnDestroy();
         Managers.Remove(this);
     }
 


### PR DESCRIPTION
## Summary
- update `CityAreaManager.OnDestroy()` to properly override `NetworkBehaviour.OnDestroy`

## Testing
- `dotnet build --nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860746670508322a0a6e4b08d1c65d9