### PR TITLE
Refactor Relay methods to return Task

### DIFF
--- a/Assets/Scripts/JoinAndCreateUI.cs
+++ b/Assets/Scripts/JoinAndCreateUI.cs
@@ -78,12 +78,20 @@ public class JoinAndCreateUI : MonoBehaviour
         }
     }
 
-    public void OnCreateGameClicked()
+    public async void OnCreateGameClicked()
     {
-        relayManager?.CreateRelay();
+        if (relayManager == null) return;
+        try
+        {
+            await relayManager.CreateRelay();
+        }
+        catch (System.Exception e)
+        {
+            Debug.LogError("[JoinAndCreateUI] Failed to create relay: " + e);
+        }
     }
 
-    public void OnJoinGameClicked()
+    public async void OnJoinGameClicked()
     {
         string code = joinCodeInput?.text?.Trim().ToUpper();
 
@@ -93,10 +101,19 @@ public class JoinAndCreateUI : MonoBehaviour
             return;
         }
 
-        relayManager?.JoinRelayWithCallback(code, () =>
+        if (relayManager == null) return;
+
+        try
         {
-            ShowLobbyPanel(code);
-        });
+            await relayManager.JoinRelayWithCallback(code, () =>
+            {
+                ShowLobbyPanel(code);
+            });
+        }
+        catch (System.Exception e)
+        {
+            Debug.LogError("[JoinAndCreateUI] Failed to join relay: " + e);
+        }
     }
 
     public void ShowLobbyPanel(string code)

--- a/Assets/Scripts/JoinGameManager.cs
+++ b/Assets/Scripts/JoinGameManager.cs
@@ -9,7 +9,7 @@ public class JoinGameManager : MonoBehaviour
     public RelayManager relayManager;
     public TMP_Text feedbackText;
 
-    public void TryJoinRoom()
+    public async void TryJoinRoom()
     {
         if (roomCodeInput == null || relayManager == null)
         {
@@ -28,11 +28,18 @@ public class JoinGameManager : MonoBehaviour
 
         SetFeedback("Joining...");
 
-        relayManager.JoinRelayWithCallback(enteredCode, () =>
+        try
         {
-            Debug.Log("[JoinGameManager] Join successful with code: " + enteredCode);
-            SetFeedback("Joined room " + enteredCode + "!");
-        });
+            await relayManager.JoinRelayWithCallback(enteredCode, () =>
+            {
+                Debug.Log("[JoinGameManager] Join successful with code: " + enteredCode);
+                SetFeedback("Joined room " + enteredCode + "!");
+            });
+        }
+        catch (System.Exception e)
+        {
+            Debug.LogError("[JoinGameManager] Join failed: " + e);
+        }
 
         StartCoroutine(CheckJoinResult());
     }

--- a/Assets/Scripts/RelayManager.cs
+++ b/Assets/Scripts/RelayManager.cs
@@ -19,13 +19,26 @@ public class RelayManager : MonoBehaviour
     private NetworkManager netManager;
     private UnityTransport transport;
 
-    private async void Awake()
+    private void Awake()
     {
-        await Initialize();
-        netManager = NetworkManager.Singleton;
-        transport = netManager?.NetworkConfig.NetworkTransport as UnityTransport;
-        if (cachedUI == null)
-            cachedUI = FindObjectOfType<JoinAndCreateUI>();
+        _ = AwakeAsync();
+    }
+
+    public async Task AwakeAsync()
+    {
+        try
+        {
+            await Initialize();
+            netManager = NetworkManager.Singleton;
+            transport = netManager?.NetworkConfig.NetworkTransport as UnityTransport;
+            if (cachedUI == null)
+                cachedUI = FindObjectOfType<JoinAndCreateUI>();
+        }
+        catch (System.Exception e)
+        {
+            Debug.LogError("[RelayManager] Awake failed: " + e);
+            throw;
+        }
     }
 
     private async Task Initialize()
@@ -39,7 +52,7 @@ public class RelayManager : MonoBehaviour
         return;
     }
 
-    public async void CreateRelay()
+    public async Task CreateRelay()
     {
         if (!CheckTransport()) return;
 
@@ -63,10 +76,11 @@ public class RelayManager : MonoBehaviour
         catch (RelayServiceException e)
         {
             Debug.LogError("[RelayManager] Relay Host Hatası: " + e);
+            throw;
         }
     }
 
-    public async void JoinRelayWithCallback(string joinCode, System.Action onSuccess)
+    public async Task JoinRelayWithCallback(string joinCode, System.Action onSuccess)
     {
         if (!CheckTransport()) return;
 
@@ -95,6 +109,7 @@ public class RelayManager : MonoBehaviour
         catch (RelayServiceException e)
         {
             Debug.LogError("[RelayManager] Relay Join Hatası: " + e);
+            throw;
         }
     }
 


### PR DESCRIPTION
## Summary
- add async Task version of `Awake` and call it from the Unity message
- refactor `CreateRelay` and `JoinRelayWithCallback` to return `Task`
- await new Task methods when creating or joining a room

## Testing
- `dotnet build -c Release Sabodeus.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686074685bf483229be40612c0a7a461