### PR TITLE
Configure MainMenu player list prefab

### DIFF
--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -3694,7 +3694,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   playerListParent: {fileID: 864417514}
-  playerEntryPrefab: {fileID: 0}
+  playerEntryPrefab: {fileID: 8281063245650581674, guid: 18ac3c8631296ec43827f07a049bdf9f, type: 3}
 --- !u!1 &1227988839
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Summary
- assign `PlayerEntry.prefab` to `LobbyPlayerListUI` in `MainMenu.unity`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68607ca38aac8322ad08b1f68a5e3ee6