### PR TITLE
Switch to gameplay scene

### DIFF
--- a/Assets/Scripts/MainMenu/StartGameHandler.cs
+++ b/Assets/Scripts/MainMenu/StartGameHandler.cs
@@ -6,16 +6,20 @@ public class StartGameHandler : MonoBehaviour
 {
     public void StartGame()
     {
+        const string gameplaySceneName = "GamePlay";
+
         if (NetworkManager.Singleton != null && NetworkManager.Singleton.IsHost)
         {
+            // Use Netcode scene manager so that every connected client changes
+            // scenes together when the host starts the game.
             NetworkManager.Singleton.SceneManager.LoadScene(
-                "SampleScene",
+                gameplaySceneName,
                 LoadSceneMode.Single);
         }
         else
         {
             Debug.LogWarning("StartGame called without host authority. Loading locally.");
-            SceneManager.LoadScene("SampleScene");
+            SceneManager.LoadScene(gameplaySceneName);
         }
     }
 }

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -8,7 +8,7 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/MainMenu.unity
     guid: 0adc3ec5eb83467489095cc1ebda80cf
-  - enabled: 0
+  - enabled: 1
     path: Assets/Scenes/GamePlay.unity
     guid: 2cda990e2423bbf4892e6590ba056729
   m_configObjects: {}


### PR DESCRIPTION
## Summary
- load `GamePlay` scene when host presses Start Game
- include `GamePlay` in build settings so network scene loading works

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686089e08ed48322a2dad8c024e3880b